### PR TITLE
Addition du dossier data, et pour Offenbach et opéra StFlour avec cts metadonnées

### DIFF
--- a/data/viaf10034167/__ cts__.xml
+++ b/data/viaf10034167/__ cts__.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ti:textgroup urn="urn:cts:libOp:viaf10034167"
+    xmlns:ti="http://chs.harvard.edu/xmlns/cts">
+    <ti:groupname xml:lang="fre">Jacques Offenbach</ti:groupname>
+</ti:textgroup>

--- a/data/viaf10034167/viaf185707290/__cts__.xml
+++ b/data/viaf10034167/viaf185707290/__cts__.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ti:work groupUrn="urn:cts:libOp:viaf10034167"
+    urn="urn:cts:libOp:viaf10034167.viaf185707290" xml:lang="fre"
+    xmlns:ti="http://chs.harvard.edu/xmlns/cts">
+    <ti:title xml:lang="fre">La Rose de Saint-Flour</ti:title>
+    <ti:edition workUrn="urn:cts:libOp:viaf10034167.viaf185707290"
+        urn="urn:cts:libOp:viaf10034167.viaf185707290.TNAH2020-fre1">
+        <ti:label xml:lang="fre">La Rose de Saint Flour, Jacques Offenbach (TNAH2020)</ti:label>
+        <ti:description xml:lang="fre">Balisage sémantique de la Rose de Saint-Flour par la promo TNAH 2020</ti:description>
+    </ti:edition>
+</ti:work>


### PR DESCRIPTION
Ajout du dossier data, qu'on utilisera tous et toutes, aussi le dossier pour Offenbach et son fichier __cts__.xml, que certains utiliseront, et le dossier pour l'opéra La Rose de Saint-Flour, plus son fichier__cts__.xml pour metadonnées. Les deux fichiers __cts__.xml ont été validés par le capitains validator, mais je vous invite de double-checker. 

Je précise que je n'ai pas mis l'encodage de mon opéra, donc n'importe qui peut mergé s'il/elle me juge compétent. 